### PR TITLE
feat: support private repos for PRs checks and fix non-master default branch for scheduled

### DIFF
--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -279,6 +279,9 @@ function Initialize-PR {
     #>
     Write-Log 'PR initialized'
 
+    # required to access releases in private GitHub repos
+    $env:SCOOP_CHECKVER_TOKEN = $env:GITHUB_TOKEN
+
     #region Stage 1 - Repository initialization
     $commented = Start-PR
     if ($null -eq $commented) { return } # Exit on not supported state

--- a/src/Action/Scheduled.psm1
+++ b/src/Action/Scheduled.psm1
@@ -14,10 +14,11 @@ function Initialize-Scheduled {
     }
 
     $params = @{
-        'Dir'         = $MANIFESTS_LOCATION
-        'Upstream'    = "${REPOSITORY}:${_BRANCH}"
-        'Push'        = $true
-        'SkipUpdated' = [bool] $env:SKIP_UPDATED
+        'Dir'          = $MANIFESTS_LOCATION
+        'Upstream'     = "${REPOSITORY}:${_BRANCH}"
+        'OriginBranch' = $_BRANCH
+        'Push'         = $true
+        'SkipUpdated'  = [bool] $env:SKIP_UPDATED
     }
     if ($env:SPECIAL_SNOWFLAKES) { $params.Add('SpecialSnowflakes', ($env:SPECIAL_SNOWFLAKES -split ',')) }
 


### PR DESCRIPTION
Fixes several things with scoop buckets for private tools (located in private Github repos):
- PR action needs `SCOOP_CHECKVER_TOKEN` to download artifacts from private GitHub repos (to validate the hash)
- Scheduled action only supports `master` default branch now since the value of the specified branch is not passed to the scoop's `auto-pr.ps1` (`OriginBranch` parameter)