### PR TITLE
feat: Support checkver's option "THROW_ERROR"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ Set of automated actions, which bucket maintainers can use to save time managing
     - String
     - If specified, scoop config 'SCOOP_BRANCH' will be configured and scoop updated
 1. `SKIP_UPDATED`
-    - Anything. Use `1`
-    - If specified, log of checkver utility will not print latest versions
+    - String. Use `'1'` or `'0'`
+    - If enabled, log of checkver utility will not print latest versions
+1. `THROW_ERROR`
+    - String. Use `'1'` or `'0'`
+    - If enabled, error from checkver utility will be thrown as exception and cause the run to fail
 1. `SPECIAL_SNOWFLAKES`
     - String
     - List of manifest names joined with `,` used as parameter for auto-pr utility.
@@ -104,6 +107,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SKIP_UPDATED: '1'
+        THROW_ERROR: '0'
 
 #.github\workflows\issues.yml
 on:

--- a/src/Action/Scheduled.psm1
+++ b/src/Action/Scheduled.psm1
@@ -18,7 +18,8 @@ function Initialize-Scheduled {
         'Upstream'     = "${REPOSITORY}:${_BRANCH}"
         'OriginBranch' = $_BRANCH
         'Push'         = $true
-        'SkipUpdated'  = [bool] $env:SKIP_UPDATED
+        'SkipUpdated'  = ($env:SKIP_UPDATED -eq '1')
+        'ThrowError'   = ($env:THROW_ERROR -eq '1')
     }
     if ($env:SPECIAL_SNOWFLAKES) { $params.Add('SpecialSnowflakes', ($env:SPECIAL_SNOWFLAKES -split ',')) }
 


### PR DESCRIPTION
For issue https://github.com/ScoopInstaller/Scoop/issues/4863.

Other than simply passing along the new option to underlying script, I noticed that the environment variables from GitHub Action yaml's `env` section are always converted to strings. For example, I tested the following in excavator.yml:
```yaml
foo: 0
foo: 1
foo: '0'
foo: '1'
foo: true
foo: false
foo: 'true'
foo: 'false'
```
For all these, `[bool] $env.foo` are always true and `($env.foo).GetType()` are always System.String. So the existing `[bool] $env:SKIP_UPDATED` is always true. Not very impacting since most people use `'1'` anyways. But if we want to default the new `THROW_ERROR` to false, I think it's better to fix this and make it consistent. There are [ways](https://stackoverflow.com/a/48865382/153133) to convert string to boolean in PowerShell in more complete way, but I think checking equalization to `'1'` is probably good enough. Let me know if this needs change.