### PR TITLE
Action/PR: Avoid $version in checkver script

### DIFF
--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -191,6 +191,15 @@ function Test-PRFile {
             # Try to match "<manifest-name>: <version>" from outputV
             $checkverRegex = "$([regex]::escape($manifest.Basename)):\s*$([regex]::escape($($object.version)))"
             $checkver = $joinedOutputV -match $checkverRegex
+            # Avoid $version in checkver script
+            if ($object.checkver.script) {
+                if ($object.checkver.script -is [string]) { $checkver_script = $object.checkver.script }
+                else { $checkver_script = $object.checkver.script -join '`r`n' }
+                if ($checkver_script.Contains('$version')) {
+                    Write-Log 'Error in checkver: $version should not be used in checkver.script'
+                    $checkver = $false
+                }
+            }
             $statuses.Add('Checkver', $checkver)
             Write-Log 'Checkver done'
 


### PR DESCRIPTION
* This is a patch to help us avoid using `$version` in checkver script, which can cause some serious errors like [#8494](https://github.com/ScoopInstaller/Extras/issues/8494) and [#8498](https://github.com/ScoopInstaller/Extras/issues/8498).

* Another way to implement this is through [schema.json](https://github.com/ScoopInstaller/Scoop/blob/master/schema.json),
  but I think implementing this in PR handler is simpler and more readable.