### PR TITLE
fix: change `GITHUB_BRANCH` to `GITHUB_REF_NAME`

### DIFF
--- a/src/Action/Scheduled.psm1
+++ b/src/Action/Scheduled.psm1
@@ -7,8 +7,8 @@ function Initialize-Scheduled {
     #>
     Write-Log 'Scheduled initialized'
 
-    if ($env:GITHUB_BRANCH) {
-        $_BRANCH = $env:GITHUB_BRANCH
+    if ($env:GITHUB_REF_NAME) {
+        $_BRANCH = $env:GITHUB_REF_NAME
     } else {
         $_BRANCH = 'master'
     }


### PR DESCRIPTION
The `GITHUB_BRANCH` is missing in the `env`, use `GITHUB_REF_NAME` instead.

See running in https://github.com/yi-Xu-0100/scoop-bucket/runs/7123394596?check_suite_focus=true

close: #10 