### PR TITLE
fix: Use new config names

### DIFF
--- a/src/Helpers.psm1
+++ b/src/Helpers.psm1
@@ -108,7 +108,7 @@ function Initialize-NeededConfiguration {
     git config --global user.email $email
     git remote 'set-url' --push origin $rem
 
-    scoop config '7ZIPEXTRACT_USE_EXTERNAL' $true
+    scoop config USE_EXTERNAL_7ZIP $true
     scoop install 'hub' -g
     if (-not $env:HUB_VERBOSE) {
         $env:HUB_VERBOSE = '1'
@@ -129,7 +129,7 @@ function Get-Manifest {
     param([Parameter(Mandatory)][String] $Name)
 
     # It should alwyas be one item. Just in case use -First
-    $gciItem = Get-Childitem $MANIFESTS_LOCATION "$Name.*" | Select-Object -First 1
+    $gciItem = Get-ChildItem $MANIFESTS_LOCATION "$Name.*" | Select-Object -First 1
     $manifest = Get-Content $gciItem.Fullname -Raw | ConvertFrom-Json
 
     return $gciItem, $manifest
@@ -217,7 +217,7 @@ function New-CheckList {
                 if ($nestedState -eq $false) { $parentState = $false }
                 $result += _res $_ ($ind + 1) $nestedState
             }
-            ($result | Where-object { ($_.Item -eq $name) -and ($null -eq $_.State) }).State = $parentState
+            ($result | Where-Object { ($_.Item -eq $name) -and ($null -eq $_.State) }).State = $parentState
         }
     }
 

--- a/src/Scoop.psm1
+++ b/src/Scoop.psm1
@@ -11,7 +11,7 @@ function Install-Scoop {
     & $f -RunAsAdmin
     if ($env:SCOOP_BRANCH) {
         Write-Log "Switching to branch: ${env:SCOOP_BRANCH}"
-        scoop config 'SCOOP_BRANCH' $env:SCOOP_BRANCH
+        scoop config SCOOP_BRANCH $env:SCOOP_BRANCH
         scoop update
     }
 }


### PR DESCRIPTION
Change config names due to https://github.com/ScoopInstaller/Scoop/pull/5116, and should be merged after that PR goes to 'master'.