### PR TITLE
chore: Some tweaks for GitHubActions

### DIFF
--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -328,7 +328,7 @@ function Initialize-PR {
     # In case of forked repository it needs to be '/github/forked_workspace'
     Get-Location | Write-Log 'Context of action'
     (Get-ChildItem $BUCKET_ROOT | Select-Object -ExpandProperty Basename) -join ', ' | Write-log 'Root Files'
-    (Get-ChildItem $MANIFESTS_LOCATION | Select-Object -ExpandProperty Basename) -join ', ' | Write-log 'Manifests'
+    (Get-ChildItem $MANIFESTS_LOCATION -Filter '*.json' -Recurse | Select-Object -ExpandProperty Basename) -join ', ' | Write-log 'Manifests'
 
     # Do not run checks on removed files
     $files = Get-AllChangedFilesInPR $EVENT.number -Filter

--- a/src/Helpers.psm1
+++ b/src/Helpers.psm1
@@ -94,7 +94,6 @@ function Initialize-NeededConfiguration {
         Initialize all settings, environment, configurations to work as expected.
     #>
 
-    scoop update
     scoop --version
     git --version
 

--- a/src/Scoop.psm1
+++ b/src/Scoop.psm1
@@ -13,6 +13,8 @@ function Install-Scoop {
         Write-Log "Switching to branch: ${env:SCOOP_BRANCH}"
         scoop config 'SCOOP_BRANCH' $env:SCOOP_BRANCH
         scoop update
+    } else {
+        scoop update
     }
 }
 


### PR DESCRIPTION
- Update Scoop once if `SCOOP_BRANCH` is specified

Before: 

![image](https://user-images.githubusercontent.com/5832170/186138164-706fc5d2-57df-4d99-b920-efe835d1c6f4.png)

After:

![image](https://user-images.githubusercontent.com/5832170/186138275-4ead9a26-331b-42f9-a93b-59fc3ef49458.png)

- Allow more than 30 files in one PR (Ref: https://docs.github.com/cn/rest/pulls/pulls#list-pull-requests-files) (50 files are changed in https://github.com/ScoopInstaller/Tests/pull/6 but only 30 of them are checked)

- Find manifests in subdir (just a log error) (related to https://github.com/ScoopInstaller/Scoop/pull/5119)

Before:

![image](https://user-images.githubusercontent.com/5832170/186139531-59756294-8e0b-4abe-918c-2854f6445f94.png)

After:

![image](https://user-images.githubusercontent.com/5832170/186139605-72b800a9-958a-4ed2-9238-9fedea376e44.png)

- See example in https://github.com/niheaven/scoop-nih/pull/5