### PR TITLE
fix: Set global preferences variables

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -1,12 +1,11 @@
-#!/usr/bin/env pwsh
-# $ErrorActionPreference = 'Stop' # Stop immediately on error, this will not lead into unwated comments.
+# Set Global Preference
+$Global:ErrorActionPreference = 'Continue'
+$Global:VerbosePreference = 'Continue'
 
 # Import all modules
 Join-Path $PSScriptRoot 'src' | Get-ChildItem -File | Select-Object -ExpandProperty Fullname | Import-Module
 
 Install-Scoop
-
-$VerbosePreference = 'Continue' # Preserve verbose in logs
 
 Test-NestedBucket
 Initialize-NeededConfiguration


### PR DESCRIPTION
Using composite runs sets the variables to non-default values, which breaks Excavator (if there is an error in the Excavator workflow run), even if `THROW_ERROR` is not set.

Example logfile without setting preference variables:
```
Property '18' does not exist on JObject.
ForEach-Object: C:\Users\runneradmin\SCOOP\apps\scoop\current\lib\json.ps1:130
Line |
 130 |      $jsonpath.split('.') | ForEach-Object {
     |                             ~~~~~~~~~~~~~~~~
     | Cannot index into a null array.

Error: Process completed with exit code 1.
```