### PR TITLE
fix(hash): Don't run au.hash check if there are no au.hash

### DIFF
--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -214,7 +214,8 @@ function Test-PRFile {
                 $statuses.Add('Autoupdate', $autoupdate)
 
                 # There is some hash property defined in autoupdate
-                if ($object.autoupdate.hash -or $object.autoupdate.architecture.PSObject.Properties.Value.hash) {
+                if ($object.autoupdate.hash -or ($object.autoupdate.architecture.PSObject.Properties.Value | Where-Object -Property hash)) {
+                    # Or use `($object | ConvertTo-Json -Depth 8) -match '(?s)"autoupdate".*?"hash"'`
                     $result = $autoupdate
                     if ($result) {
                         # If any result contains any item with 'Could not find hash*' there is hash extraction error.


### PR DESCRIPTION
- Related to https://github.com/ScoopInstaller/Extras/pull/9653#issuecomment-1303918228

<img width="642" alt="CleanShot 2022-11-06 at 11 41 15@2x" src="https://user-images.githubusercontent.com/5832170/200152970-5fa0d262-9525-41f3-9fe0-e05862f8cf9a.png">
