### PR TITLE
fix: ensure manifests use the standard JSON format

### DIFF
--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -143,7 +143,8 @@ function Test-PRFile {
         # For Some reason -ErrorAction is not honored for convertfrom-json
         $old_e = $ErrorActionPreference
         $ErrorActionPreference = 'SilentlyContinue'
-        $object = Get-Content $manifest.Fullname -Raw | ConvertFrom-Json
+        # Formatting JSON with PowerShell 5.1, ensures that the JSON string conforms to the standard JSON format.
+        $object = Get-Content $manifest.Fullname -Raw | powershell -command 'ConvertFrom-Json -InputObject $input | ConvertTo-Json' | ConvertFrom-Json
         $ErrorActionPreference = $old_e
 
         if ($null -eq $object) {


### PR DESCRIPTION
The `ConvertFrom-Json` method in PowerShell 7 supports JSON with comments.
The `ConvertFrom-Json` method in PowerShell 5 supports only standard JSON.
See the documentation for details: [ConvertFrom-Json](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-5.1#:~:text=Beginning%20with%20PowerShell%206)

Formatting the manifest file again using the `ConvertFrom-Json` method in PowerShell 5 ensures that the manifest file is in standard JSON format (without extra commas, comments, etc.).

Relates to https://github.com/ScoopInstaller/Extras/pull/12216