### PR TITLE
fix: Apply several fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,9 @@ It could be one of these:
 
 As soon as a PR **is created** or the **comment `/verify` is posted** to it, validation tests are executed (see [wiki](https://github.com/ScoopInstaller/GithubActions/wiki/Pull-Request-Checks)) for detailed desciption):
 
-- ❗❗ **Pull request created from forked repository cannot be verified due to security concern from GitHub side** ❗❗
-    - Manual `/verify` comment is needed
-
 #### Overview of validatiors
 
+1. JSON standard format check 
 1. Required properties (`License`, `Description`) are in place
 1. Hashes of files are correct
 1. Checkver functionality
@@ -148,7 +146,7 @@ jobs:
 
 #.github\workflows\pull_request.yml
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened ]
 name: Pull Requests
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - run: ${{ github.action_path }}/action.ps1
-      shell: pwsh
+      shell: powershell
 
 branding:
   icon: package

--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -302,11 +302,11 @@ function Initialize-PR {
         Write-Log 'Forked repository'
 
         # There is no need to run whole action under forked repository due to permission problem
-        if ($commented -eq $false) {
-            Write-Log 'Cannot comment with read only token'
-            # TODO: Execute it and adopt pester like checks
-            return
-        }
+        # if ($commented -eq $false) {
+        #     Write-Log 'Cannot comment with read only token'
+        #     # TODO: Execute it and adopt pester like checks
+        #     return
+        # }
 
         $REPOSITORY_forked = "$($head.repo.full_name):$($head.ref)"
         Write-Log 'Repo' $REPOSITORY_forked

--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -301,12 +301,14 @@ function Initialize-PR {
     if ($head.repo.fork) {
         Write-Log 'Forked repository'
 
-        # There is no need to run whole action under forked repository due to permission problem
-        # if ($commented -eq $false) {
-        #     Write-Log 'Cannot comment with read only token'
-        #     # TODO: Execute it and adopt pester like checks
-        #     return
-        # }
+        if ($EVENT_TYPE -ne 'pull_request_target') {
+            # There is no need to run whole action under forked repository due to permission problem
+            if ($commented -eq $false) {
+                Write-Log 'Cannot comment with read only token'
+                # TODO: Execute it and adopt pester like checks
+                return
+            }
+        }
 
         $REPOSITORY_forked = "$($head.repo.full_name):$($head.ref)"
         Write-Log 'Repo' $REPOSITORY_forked

--- a/src/ActionWrapper.psm1
+++ b/src/ActionWrapper.psm1
@@ -8,6 +8,7 @@ function Invoke-Action {
     #>
     switch ($EVENT_TYPE) {
         'pull_request' { Initialize-PR }
+        'pull_request_target' { Initialize-PR }
         'issue_comment' { Initialize-PR }
         'schedule' { Initialize-Scheduled }
         'workflow_dispatch' { Initialize-Scheduled }

--- a/src/ActionWrapper.psm1
+++ b/src/ActionWrapper.psm1
@@ -1,5 +1,5 @@
 Join-Path $PSScriptRoot 'Helpers.psm1' | Import-Module
-Join-Path $PSScriptRoot 'Action' | Get-ChildItem -Filter '*.psm1' | Import-Module
+Join-Path $PSScriptRoot 'Action' | Get-ChildItem -Filter '*.psm1' | Select-Object -ExpandProperty Fullname | Import-Module
 
 function Invoke-Action {
     <#

--- a/src/Helpers.psm1
+++ b/src/Helpers.psm1
@@ -128,7 +128,7 @@ function Get-Manifest {
     param([Parameter(Mandatory)][String] $Name)
 
     # It should alwyas be one item. Just in case use -First
-    $gciItem = Get-ChildItem $MANIFESTS_LOCATION "$Name.*" | Select-Object -First 1
+    $gciItem = Get-ChildItem -Path $MANIFESTS_LOCATION -Filter "$Name.json" -Recurse | Select-Object -First 1
     $manifest = Get-Content $gciItem.Fullname -Raw | ConvertFrom-Json
 
     return $gciItem, $manifest


### PR DESCRIPTION
1. Change to use `powershell` shell for jobs execution
    - prior to this, manifest validation was done with `ConvertFrom-Json` from `pwsh` which cannot detect errors like tailing commas. Close #38 
1. Support nested bucket structure
    - an omission of https://github.com/ScoopInstaller/Scoop/pull/5119
1. Add `pull_request_target` event trigger
    - [manifest validation to pull-requests from fork](https://github.com/ScoopInstaller/GithubActions/pull/38#issuecomment-1951673411) are now functional
    - not a breaking change, but downstream bucket  repos may need update their workflow (change `pull_request` to `pull_request_target` in _.github\workflows\pull_request.yml_) to adopt this improvement
