### PR TITLE
feat: Support `FORCE_PWSH` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Set of automated actions, which bucket maintainers can use to save time managing
 1. `SPECIAL_SNOWFLAKES`
     - String
     - List of manifest names joined with `,` used as parameter for auto-pr utility.
+1. `USE_CORE`
+    - String. Use `'1'` or `'0'`
+    - If enabled, `pwsh` (PowerShell Core) will be used instead of `powershell` (Windows PowerShell).
+    - Use `powershell` by default. More: [#38](https://github.com/ScoopInstaller/GithubActions/pull/38) [#39](https://github.com/ScoopInstaller/GithubActions/pull/39) [#46](https://github.com/ScoopInstaller/GithubActions/pull/46)
 
 ## Available actions
 
@@ -77,7 +81,7 @@ As soon as a PR **is created** or the **comment `/verify` is posted** to it, val
 
 #### Overview of validatiors
 
-1. JSON standard format check 
+1. JSON standard format check
 1. Required properties (`License`, `Description`) are in place
 1. Hashes of files are correct
 1. Checkver functionality
@@ -109,6 +113,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SKIP_UPDATED: '1'
         THROW_ERROR: '0'
+        USE_CORE: '0'
 
 #.github\workflows\issues.yml
 on:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Set of automated actions, which bucket maintainers can use to save time managing
 1. `SPECIAL_SNOWFLAKES`
     - String
     - List of manifest names joined with `,` used as parameter for auto-pr utility.
-1. `USE_CORE`
+1. `FORCE_PWSH`
     - String. Use `'1'` or `'0'`
     - If enabled, `pwsh` (PowerShell Core) will be used instead of `powershell` (Windows PowerShell).
     - Use `powershell` by default. More: [#38](https://github.com/ScoopInstaller/GithubActions/pull/38) [#39](https://github.com/ScoopInstaller/GithubActions/pull/39) [#46](https://github.com/ScoopInstaller/GithubActions/pull/46)
@@ -113,7 +113,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SKIP_UPDATED: '1'
         THROW_ERROR: '0'
-        USE_CORE: '0'
+        FORCE_PWSH: '0'
 
 #.github\workflows\issues.yml
 on:

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - run: ${{ github.action_path }}/action.ps1
-      shell: ${{ env.USE_CORE == '1' && 'pwsh' || 'powershell' }}
+      shell: ${{ env.FORCE_PWSH == '1' && 'pwsh' || 'powershell' }}
 
 branding:
   icon: package

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - run: ${{ github.action_path }}/action.ps1
-      shell: powershell
+      shell: ${{ env.USE_CORE == '1' && 'pwsh' || 'powershell' }}
 
 branding:
   icon: package


### PR DESCRIPTION
I encountered an execution error problem. It was caused by using Windows PowerShell.

For example, I'm using SQLite.dll assembly in scoop bucket. The GitHub Actions worked fine until I switched the Chinese characters to English.

```
2024-11-09T*Z SQLite assembly not loaded
2024-11-09T*Z At D:\a\B\C\bin\SQLite.psm1:52 char:38
2024-11-09T*Z + ... if (-not $Script:SQLiteLoaded) { throw 'SQLite assembly not loaded' }
2024-11-09T*Z +                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-11-09T*Z     + CategoryInfo          : OperationStopped: (SQLite assembly not loaded:String) [], RuntimeException
2024-11-09T*Z    + FullyQualifiedErrorId : SQLite assembly not loaded
2024-11-09T*Z  
2024-11-09T*Z ##[error]Process completed with exit code 1.
```

![](https://github.com/user-attachments/assets/7c905242-335d-40ae-b7cd-0b8750f13c10)

It didn't appear before because Chinese characters could not be recognized by Windows PowerShell correctly, which prevented the code from being executed.

![](https://github.com/user-attachments/assets/9b93d0bc-7516-49c7-a943-bbe4bc5ac993)

Another issue on this is that `Join-Path` behaves differently in different versions.

![](https://github.com/user-attachments/assets/dd1eb74d-306e-4af1-bc49-761b561a20c6)

Even in this single instance, there are three critical flaws with Windows PowerShell:

1. Windows PowerShell has poor support for encoding.
2. Windows PowerShell has difficulty to load newer DLLs.
3. Windows PowerShell has different behaviours in some functions.

Recently, I was struggling with `auto-update` written in my local VS Code + PowerShell Core environment that couldn't be executed in the GitHub Actions. It worked fine locally, but it took more than 20 minutes in the cloud and it didn't get it right, and it is useless to set up the proxy. I can't to rule out that it's a network problem, but it may have something to do with Windows PowerShell.

I'd suggest providing an option like `USE_CORE` for the user to manually choose whether or not to use PowerShell Core. Such as checking for updates, there is no need to consider the compatibility of the client, and it can even be implemented with third-party tools. It's harmless to use PowerShell Core for this kind of thing.

[#38](https://github.com/ScoopInstaller/GithubActions/pull/38) [#39](https://github.com/ScoopInstaller/GithubActions/pull/39) [#46](https://github.com/ScoopInstaller/GithubActions/pull/46)