### PR TITLE
PR manifest validation - Add check for uneccessary arrays

### DIFF
--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -167,7 +167,7 @@ function Test-PRFile {
         $statuses.Add('License', ([bool] $object.license))
         # TODO: More advanced license checks
 
-        # Don't use array for some manifest root properties they only contain one value
+        # Don't use array for some manifest root properties if they only contain one value
         $UnneccessaryArrays = [bool] $true
         foreach ($Item in '##', 'notes', 'pre_install', 'post_install', 'pre_uninstall', 'post_uninstall') {
             if (

--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -171,12 +171,12 @@ function Test-PRFile {
         $UnneccessaryArrays = [bool] $true
         foreach ($Item in '##', 'notes', 'pre_install', 'post_install', 'pre_uninstall', 'post_uninstall') {
             if (
-                $ManifestAsHashtable.'Keys'.Contains($Item) -and
-                $ManifestAsHashtable.$Item -is [array] -and
-                $ManifestAsHashtable.$Item.'Count' -le 1
+                $object.PSObject.Properties.Name.Contains($Item) -and
+                $object.$Item -is [array] -and
+                $object.$Item.'Count' -le 1
             ) {
                 $UnneccessaryArrays = [bool] $false
-                Write-Log ('"{0}" is array but only contains "{1}" element.' -f $Item, $ManifestAsHashtable.$Item.'Count'.ToString())
+                Write-Log ('"{0}" is array but only contains "{1}" element.' -f $Item, $object.$Item.'Count'.ToString())
             }
         }
         $statuses.Add('UnneccessaryArrays', $UnneccessaryArrays)

--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -166,6 +166,20 @@ function Test-PRFile {
         $statuses.Add('Description', ([bool] $object.description))
         $statuses.Add('License', ([bool] $object.license))
         # TODO: More advanced license checks
+
+        # Don't use array for elements if they only contain one item
+        $UnneccessaryArrays = [bool] $true
+        foreach ($Item in '##', 'notes', 'pre_install', 'post_install', 'pre_uninstall', 'post_uninstall') {
+            if (
+                $ManifestAsHashtable.'Keys'.Contains($Item) -and
+                $ManifestAsHashtable.$Item -is [array] -and
+                $ManifestAsHashtable.$Item.'Count' -le 1
+            ) {
+                $UnneccessaryArrays = [bool] $false
+                Write-Log ('"{0}" is array but only contains "{1}" element.' -f $Item, $ManifestAsHashtable.$Item.'Count'.ToString())
+            }
+        }
+        $statuses.Add('UnneccessaryArrays',$UnneccessaryArrays)
         #endregion 1. Property checks
 
         #region 2. Hashes

--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -167,7 +167,7 @@ function Test-PRFile {
         $statuses.Add('License', ([bool] $object.license))
         # TODO: More advanced license checks
 
-        # Don't use array for elements if they only contain one item
+        # Don't use array for some manifest root properties they only contain one value
         $UnneccessaryArrays = [bool] $true
         foreach ($Item in '##', 'notes', 'pre_install', 'post_install', 'pre_uninstall', 'post_uninstall') {
             if (

--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -179,7 +179,7 @@ function Test-PRFile {
                 Write-Log ('"{0}" is array but only contains "{1}" element.' -f $Item, $ManifestAsHashtable.$Item.'Count'.ToString())
             }
         }
-        $statuses.Add('UnneccessaryArrays',$UnneccessaryArrays)
+        $statuses.Add('UnneccessaryArrays', $UnneccessaryArrays)
         #endregion 1. Property checks
 
         #region 2. Hashes


### PR DESCRIPTION
Check if manifest has an unnecessary array for some root properties. If only one value and value is array = failed.