### PR TITLE
feat: Provide link to logs in the comment

### DIFF
--- a/src/Action/Issue.psm1
+++ b/src/Action/Issue.psm1
@@ -21,7 +21,7 @@ function Test-Hash {
     if (($outputH[-2] -like 'OK') -and ($outputH[-1] -like 'Writing*')) {
         Write-Log 'Cannot reproduce'
 
-        Add-Comment -ID $IssueID -Message @(
+        Add-Comment -ID $IssueID -AppendLogLink -Message @(
             'Cannot reproduce'
             ''
             'Are you sure your scoop is up to date? Clean cache and reinstall'
@@ -58,7 +58,7 @@ function Test-Hash {
             'Please try again later. If it persists, please reach out to the maintainers for help.'
         )
 
-        Add-Comment -ID $IssueID -Message $message
+        Add-Comment -ID $IssueID -Message $message -AppendLogLink
     } else {
         Write-Log 'Hash mismatch confirmed.'
 
@@ -121,7 +121,7 @@ function Test-Hash {
                 git push
             }
         }
-        Add-Comment -ID $IssueID -Message $message
+        Add-Comment -ID $IssueID -Message $message -AppendLogLink
     }
 }
 
@@ -140,7 +140,7 @@ function Test-Downloading {
     if (!$broken_urls) {
         Write-Log 'Cannot reproduce'
 
-        Add-Comment -ID $IssueID -Message @(
+        Add-Comment -ID $IssueID -AppendLogLink -Message @(
             'Cannot reproduce.'
             ''
             'All files could be downloaded without any issue.'
@@ -158,7 +158,7 @@ function Test-Downloading {
     } else {
         Write-Log 'Broken URLs' $broken_urls
 
-        Add-Comment -ID $IssueID -Message (@(
+        Add-Comment -ID $IssueID -AppendLogLink -Message (@(
                 'You are right. Thank you for reporting.',
                 '',
                 'Following URLs are not accessible:'
@@ -197,7 +197,7 @@ function Initialize-Issue {
     try {
         $null, $manifest_loaded = Get-Manifest $problematicName
     } catch {
-        Add-Comment -ID $id -Message "The specified manifest ``$problematicName`` does not exist in this bucket. Make sure you opened the issue in the correct bucket."
+        Add-Comment -ID $id -AppendLogLink -Message "The specified manifest ``$problematicName`` does not exist in this bucket. Make sure you opened the issue in the correct bucket."
         Add-Label -Id $id -Label 'invalid'
         Remove-Label -Id $id -Label 'verify'
         Close-Issue -ID $id
@@ -205,7 +205,7 @@ function Initialize-Issue {
     }
 
     if ($manifest_loaded.version -ne $problematicVersion) {
-        Add-Comment -ID $id -Message @(
+        Add-Comment -ID $id -AppendLogLink -Message @(
             # TODO: Try to find specific version of arhived manifest
             "You reported version ``$problematicVersion``, but the latest available version is ``$($manifest_loaded.version)``."
             ''

--- a/src/Action/Issue/Extraction.psm1
+++ b/src/Action/Issue/Extraction.psm1
@@ -67,7 +67,7 @@ function Test-ExtractDir {
         )
     }
 
-    Add-Comment -ID $IssueID -Message $message
+    Add-Comment -ID $IssueID -Message $message -AppendLogLink
 }
 
 Export-ModuleMember -Function Test-ExtractDir

--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -107,12 +107,9 @@ function New-FinalMessage {
         $labelsToRemove += 'manifest-fix-needed'
     }
 
-    # TODO: Comment URL to action log
-    # Add-IntoArray $message "[_See log of all checks_](https://github.com/$REPOSITORY/runs/$RUN_ID)"
-
     Remove-Label -ID $prID -Label $labelsToRemove
     Add-Label -ID $prID -Label $labelsToAdd
-    Add-Comment -ID $prID -Message $message
+    Add-Comment -ID $prID -Message $message -AppendLogLink
 }
 
 function Test-PRFile {

--- a/src/Variables.psm1
+++ b/src/Variables.psm1
@@ -21,6 +21,9 @@ $EVENT_TYPE = $env:GITHUB_EVENT_NAME
 
 # user/repo format
 $REPOSITORY = $env:GITHUB_REPOSITORY
+# Github Action job name & run ID
+$JOB = $env:GITHUB_JOB
+$RUN_ID = $env:GITHUB_RUN_ID
 # Location of bucket
 $BUCKET_ROOT = $env:GITHUB_WORKSPACE
 # Binaries from scoop. No need to rely on bucket specific binaries
@@ -31,5 +34,7 @@ $MANIFESTS_LOCATION = Join-Path $BUCKET_ROOT 'bucket'
 
 $DEFAULT_EMAIL = '41898282+github-actions[bot]@users.noreply.github.com'
 
-Export-ModuleMember -Variable EVENT, EVENT_RAW, EVENT_TYPE, REPOSITORY, BUCKET_ROOT, BINARIES_FOLDER, `
+Export-ModuleMember -Variable EVENT, EVENT_RAW, EVENT_TYPE, `
+    REPOSITORY, JOB, RUN_ID, `
+    BUCKET_ROOT, BINARIES_FOLDER, `
     MANIFESTS_SCHEMA, MANIFESTS_LOCATION, NON_ZERO, DEFAULT_EMAIL


### PR DESCRIPTION
#### Motivation and Context

To find the relevant logs for an issue/PR, we have to search manually in the Actions/Checks page.

Providing URL link to logs directly from the run result will improve this experience.

#### Description

This PR makes the following changes:

- feat: Provide link to logs in the comment.

#### Test Cases

- Issue Handler
  - Pre-check
    - version outdated: https://github.com/z-Fng/scoop-games/issues/39
    - manifest not found: https://github.com/z-Fng/scoop-games/issues/40
  - Handlers
    - hash check failed : https://github.com/z-Fng/scoop-games/issues/41
    - download failed: https://github.com/z-Fng/scoop-games/issues/35

- PR Handler
  - Pass: https://github.com/z-Fng/scoop-games/pull/38
  - Fail: https://github.com/z-Fng/scoop-games/pull/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issue and PR comments now automatically include a link to the workflow logs for easier troubleshooting.

* **Improvements**
  * Comment text refined with clearer guidance when an issue cannot be reproduced (includes steps to update/reinstall and re-run checks).
  * Final PR messages clarified for failure/success scenarios.

* **Chores**
  * Updated GitHub API authentication for outgoing requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->