### PR TITLE
feat: add support for repository_dispatch event

### DIFF
--- a/src/ActionWrapper.psm1
+++ b/src/ActionWrapper.psm1
@@ -12,6 +12,7 @@ function Invoke-Action {
         'issue_comment' { Initialize-PR }
         'schedule' { Initialize-Scheduled }
         'workflow_dispatch' { Initialize-Scheduled }
+        'repository_dispatch' { Initialize-Scheduled }
         'issues' { Initialize-Issue }
         default { Write-Log 'Not supported event type' }
     }


### PR DESCRIPTION
This pull request makes a minor update to the event handling logic in `src/ActionWrapper.psm1`. The change ensures that the `repository_dispatch` event is now handled in the same way as scheduled events.

* Added support for the `repository_dispatch` event by mapping it to the `Initialize-Scheduled` function in the `Invoke-Action` handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the repository_dispatch event, allowing workflows to be triggered via the repository API or external integrations. This complements existing schedule and manual triggers, enabling automated runs initiated by third-party systems.
* **Other**
  * No changes to public interfaces; behavior remains consistent aside from the new trigger option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->