### PR TITLE
feat: Add lint checks

### DIFF
--- a/src/Action/PR.psm1
+++ b/src/Action/PR.psm1
@@ -162,6 +162,26 @@ function Test-PRFile {
             continue
         }
 
+        #region Lint
+        Write-Log 'Lint'
+
+        try {
+            & (Join-Path $BINARIES_FOLDER 'formatjson.ps1') -App $manifest.Basename -Dir $MANIFESTS_LOCATION
+
+            $contentFormated = Get-Content -Path $manifest.FullName -Raw
+
+            $lint = $content -eq $contentFormated
+        } catch {
+            $lint = $false
+
+            Write-Log 'Lint Checks' @("Exception occurred: $($_.Exception.Message)", "$($_.ScriptStackTrace)")
+        }
+
+        $statuses.Add('Lint', $lint)
+
+        Write-Log 'Lint done'
+        #endregion
+
         #region 1. Property checks
         $statuses.Add('Description', ([bool] $object.description))
         $statuses.Add('License', ([bool] $object.license))


### PR DESCRIPTION
#### Description
This PR makes the following changes:
- feat: Add lint checks. 

#### Motivation and Context
Relates to:
- #50 
- #51

As mentioned in https://github.com/ScoopInstaller/GithubActions/pull/51#issuecomment-3304292102 and https://github.com/ScoopInstaller/Scoop/issues/2609#issuecomment-423308364.
Perform lint check by comparing the original file with the output from the 'formatjson' command (a built-in tool in Scoop).

- It can reduce the workload for maintainers.
- It can also provide contributors with an easy way to fix these issues—all they need to do is running a single command like:
```powershell
.\bin\formatjson.ps1 -App appName
```
- If the _formatjson_ command can be extended, it is possible to resolve https://github.com/ScoopInstaller/GithubActions/pull/50 easily using this method as well.

#### Testcase
- https://github.com/z-Fng/scoop-games/pull/55

### For maintainers
Please update the [wiki of PR checks](https://github.com/ScoopInstaller/GithubActions/wiki/Pull-Request-Checks) before merging. I don't have the privilege to do it.

````
## Lint
Follow the [contribution guidelines](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md#for-scoop-buckets) for writing manifests.

Navigate to the root of the bucket and execute the following command to format the manifests:

```powershell
.\bin\formatjson.ps1 -App appName
```
````

<img width="1124" height="183" alt="image" src="https://github.com/user-attachments/assets/e1508f0c-772b-42a9-b90b-f3b0c9c9f852" />
