### PR TITLE
feat: Allow configuring PowerShell preference variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Set of automated actions, which bucket maintainers can use to save time managing
 1. `SPECIAL_SNOWFLAKES`
     - String
     - List of manifest names joined with `,` used as parameter for auto-pr utility.
+1. [PowerShell Preference Variables](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables)
+    - If an environment variable with the same name as the following PowerShell preference variable exists, its value will be assigned to the corresponding PowerShell preference variable:
+
+    | Name                                                         | Type   | Default Value        |
+    | ------------------------------------------------------------ | ------ | -------------------- |
+    | [DebugPreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#debugpreference) | String | `'SilentlyContinue'` |
+    | [InformationPreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#informationpreference) | String | `'SilentlyContinue'` |
+    | [VerbosePreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#verbosepreference) | String | `'SilentlyContinue'` |
+    | [WarningPreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#warningpreference) | String | `'Continue'`         |
 
 ## Available actions
 

--- a/action.ps1
+++ b/action.ps1
@@ -1,7 +1,3 @@
-# Set Global Preference
-$Global:ErrorActionPreference = 'Continue'
-$Global:VerbosePreference = 'Continue'
-
 # Import all modules
 Join-Path $PSScriptRoot 'src' | Get-ChildItem -File | Select-Object -ExpandProperty Fullname | Import-Module
 

--- a/src/Variables.psm1
+++ b/src/Variables.psm1
@@ -1,3 +1,38 @@
+function Initialize-PreferenceVariable {
+    <#
+    .SYNOPSIS
+        Initializes PowerShell preference variables based on environment variables or default values.
+    #>
+
+    $DefaultPreferences = [ordered]@{
+        # Set ErrorActionPreference first and prevent it from being overridden by the environment variable.
+        ErrorActionPreference = @{ Value = 'Continue'; IgnoreEnv = $true }
+        DebugPreference       = @{ Value = 'SilentlyContinue' }
+        InformationPreference = @{ Value = 'SilentlyContinue' }
+        VerbosePreference     = @{ Value = 'SilentlyContinue' }
+        WarningPreference     = @{ Value = 'Continue' }
+    }
+
+    foreach ($Name in $DefaultPreferences.Keys) {
+        $Preference = $DefaultPreferences[$Name]
+        $Value = $Preference.Value
+
+        $EnvValue = Get-Item "Env:$Name" -ErrorAction Ignore | Select-Object -ExpandProperty Value
+
+        if ((-not $Preference.IgnoreEnv) -and ($EnvValue)) {
+            $Value = $EnvValue
+        }
+
+        # Use built-in output functions instead of Write-Log here to avoid dependency issues
+        Write-Host "Setting $Name to $Value ..."
+
+        Set-Variable -Name $Name -Value $Value -Scope Global
+    }
+}
+
+# Initialize PowerShell Preference Variables
+Initialize-PreferenceVariable
+
 # Environment
 $env:SCOOP = Join-Path $env:USERPROFILE 'SCOOP'
 $env:SCOOP_HOME = Join-Path $env:SCOOP 'apps\scoop\current'


### PR DESCRIPTION
### Description
This PR makes the following changes:
- feat: Allow configuring some of PowerShell preference variables.
    | Name                                                         | Type   | Default Value        |
    | ------------------------------------------------------------ | ------ | -------------------- |
    | [DebugPreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#debugpreference) | String | `'SilentlyContinue'` |
    | [InformationPreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#informationpreference) | String | `'SilentlyContinue'` |
    | [VerbosePreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#verbosepreference) | String | `'SilentlyContinue'` |
    | [WarningPreference](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#warningpreference) | String | `'Continue'`         |
- chore: Change default `VerbosePreference` from **`Continue`** to **`SilentlyContinue`**.

### Motivation and Context
- Most Verbose outputs are unnecessary at the moment. Setting VerbosePreference to Continue can suppress these outputs.
  Closes #66
- Allow configuring PowerShell preference variables, which lays the groundwork for future code refactoring (such as log level management).
  Relates to #33

### Test Cases
- https://github.com/z-Fng/Scoop-Extras/actions/runs/19240280236/job/55000983538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a PowerShell preference variables section with defaults and a link to Microsoft docs.

* **Behavioral Change**
  * Removed explicit global preference settings that previously forced continue behavior, changing default error/verbosity handling.

* **Refactor**
  * Centralized startup initialization for preference variables with support for optional environment overrides and startup logging of applied settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->