### PR TITLE
chore: add log message for protected default branch case

### DIFF
--- a/src/Action/Issue.psm1
+++ b/src/Action/Issue.psm1
@@ -90,6 +90,7 @@ function Test-Hash {
         } else {
             # Check if default branch is protected
             if (((Invoke-GithubRequest "repos/$REPOSITORY/branches/$masterBranch").Content | ConvertFrom-Json).protected) {
+                Write-Log 'The default branch is protected. PR will be created.'
                 Write-Log 'PR - Create new branch and post PR'
 
                 $branch = "$manifestNameAsInBucket-hash-fix-$(Get-Random -Maximum 258258258)"


### PR DESCRIPTION
- Add log message for protected default branch case.
- It helps us understand in the workflow logs why a PR was created here instead of a commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational log message to notify users when the default branch is protected prior to pull request creation, providing better visibility into the process workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->