### PR TITLE
fix: Refine branch protection check for direct pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It could be one of these:
                     1. Check if direct push to default branch is restricted (e.g., requires PR, update restriction, or branch is locked)
                     1. If restricted:
                         1. New branch `<manifest>-hash-fix-<random>` is created
-                        1. Changes are commited and pushed to new branch
+                        1. Changes are committed and pushed to new branch
                         1. New PR is created from this branch
                     1. If not restricted:
                         1. Fixes are committed and pushed directly to default branch

--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ It could be one of these:
                     1. Comment to issue is posted with reference to PR
                     1. Label `duplicate` added
                 1. If none
-                    1. New branch `<manifest>-hash-fix-<random>` is created
-                    1. Changes are commited
-                    1. New PR is created from this branch
+                    1. Check if direct push to default branch is restricted (e.g., requires PR, update restriction, or branch is locked)
+                    1. If restricted:
+                        1. New branch `<manifest>-hash-fix-<random>` is created
+                        1. Changes are commited and pushed to new branch
+                        1. New PR is created from this branch
+                    1. If not restricted:
+                        1. Fixes are committed and pushed directly to default branch
             1. Labels `hash-fix-needed`, `verified` are added
         1. No problem
             1. Comment on issue is posted about hashes being right and possible causes

--- a/src/Action/Issue.psm1
+++ b/src/Action/Issue.psm1
@@ -88,8 +88,41 @@ function Test-Hash {
             Invoke-GithubRequest "repos/$REPOSITORY/pulls/$prID" -Method Patch -Body @{ 'body' = (@("- Closes #$IssueID", $pr.body) -join "`r`n") }
             Add-Label -ID $IssueID -Label 'duplicate'
         } else {
-            # Check if default branch is protected
-            if (((Invoke-GithubRequest "repos/$REPOSITORY/branches/$masterBranch").Content | ConvertFrom-Json).protected) {
+            # Check if direct push to default branch is allowed
+            $branchData = (Invoke-GithubRequest "repos/$REPOSITORY/branches/$masterBranch").Content | ConvertFrom-Json
+            $prRequired = $false
+            if ($branchData.protected) {
+                Write-Log "Branch $masterBranch is protected. Checking if direct push is allowed..."
+                try {
+                    # Try getting detailed protection rules (includes legacy and modern rulesets)
+                    # Official path: GET /repos/{owner}/{repo}/rules/branches/{branch}
+                    $rules = (Invoke-GithubRequest "repos/$REPOSITORY/rules/branches/$masterBranch").Content | ConvertFrom-Json
+                    # Direct push is blocked if there are rules:
+                    # - 'pull_request': Requires a pull request before merging
+                    # - 'update': Restricts updates (direct pushes) to the branch
+                    # - 'lock': The branch is read-only
+                    $prRequired = $null -ne ($rules | Where-Object { $_.type -in @('pull_request', 'update', 'lock') })
+                    Write-Log "Rules evaluation result. PR required: $prRequired"
+                    Write-Log "Active rules" ($rules | Select-Object -Property type)
+                } catch {
+                    Write-Log "Rulesets API failed or unavailable, falling back to legacy Protection API. Error: $($_.Exception.Message)"
+                    try {
+                        # Fallback to legacy protection API if rules API is not available
+                        $protection = (Invoke-GithubRequest "repos/$REPOSITORY/branches/$masterBranch/protection").Content | ConvertFrom-Json
+                        $prRequired = $null -ne $protection.required_pull_request_reviews -or
+                                      $null -ne $protection.restrictions -or
+                                      ($null -ne $protection.lock_branch -and $protection.lock_branch.enabled)
+                        Write-Log "Protection API evaluation result. PR required: $prRequired"
+                        Write-Log "Protection details" $protection
+                    } catch {
+                        # If we cannot determine why it's protected, assume it's restrictive for safety
+                        Write-Log "Failed to retrieve protection details. Error: $($_.Exception.Message). Defaulting to PR required for safety."
+                        $prRequired = $true
+                    }
+                }
+            }
+
+            if ($prRequired) {
                 Write-Log 'PR - Create new branch and post PR'
 
                 $branch = "$manifestNameAsInBucket-hash-fix-$(Get-Random -Maximum 258258258)"

--- a/src/Action/Issue.psm1
+++ b/src/Action/Issue.psm1
@@ -101,7 +101,7 @@ function Test-Hash {
                     # - 'pull_request': Requires a pull request before merging
                     # - 'update': Restricts updates (direct pushes) to the branch
                     # - 'lock': The branch is read-only
-                    $prRequired = $null -ne ($rules | Where-Object { $_.type -in @('pull_request', 'update', 'lock') })
+                    $prRequired = ($rules | Where-Object { $_.type -in @('pull_request', 'update', 'lock') }).Count -gt 0
                     Write-Log "Rules evaluation result. PR required: $prRequired"
                     Write-Log "Active rules" ($rules | Select-Object -Property type)
                 } catch {


### PR DESCRIPTION
#### Motivation
- https://github.com/ScoopInstaller/Extras/issues/17703#issuecomment-4344624317

Recent adjustments to bucket workflow permissions and changes to branch restrictions have caused the existing hash-fixing workflow to stop working properly. Simply checking whether a branch is protected to determine whether to create a pull request is no longer sufficient; we now need to check whether direct pushes can be performed.

Note: **This may be a breaking change.** But few users should be affected — only those with branch protection enabled but without "Require a pull request before merging" enabled.
#### Changes
- Specifically check for 'pull_request', 'update', or 'lock' rules
- Add fallback to legacy Protection API if Rulesets API is unavailable
- Improve logging for better traceability of push/PR decisions
- Update branch protection support info in README
#### Testcase
- https://github.com/z-Fng/Scoop-Extras/issues/41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow now intelligently detects branch protection rules to determine whether to create pull requests or commit directly to the default branch when fixing hash mismatches.

* **Documentation**
  * Updated workflow documentation explaining conditional branching behavior based on branch restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->