### PR TITLE
chore: Remove explicit VerbosePreference setting, default to SilentlyContinue

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -1,6 +1,6 @@
 # Set Global Preference
 $Global:ErrorActionPreference = 'Continue'
-$Global:VerbosePreference = 'Continue'
+$Global:VerbosePreference = 'SilentlyContinue'
 
 # Import all modules
 Join-Path $PSScriptRoot 'src' | Get-ChildItem -File | Select-Object -ExpandProperty Fullname | Import-Module

--- a/action.ps1
+++ b/action.ps1
@@ -1,6 +1,5 @@
 # Set Global Preference
 $Global:ErrorActionPreference = 'Continue'
-$Global:VerbosePreference = 'SilentlyContinue'
 
 # Import all modules
 Join-Path $PSScriptRoot 'src' | Get-ChildItem -File | Select-Object -ExpandProperty Fullname | Import-Module


### PR DESCRIPTION
## Motivation and Context
Most Verbose outputs are unnecessary at the moment. Setting VerbosePreference to SilentlyContinue can suppress these outputs.

Relates to:
- #66
- #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced verbose output during action execution to produce cleaner logs and a smoother user experience.
  * Maintained error handling behavior while removing the explicit verbose setting to rely on default or external logging controls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/GithubActions/pull/76)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->