### PR TITLE
fix: avoid validation error when issue body is empty

### DIFF
--- a/src/Action/Issue/Extraction.psm1
+++ b/src/Action/Issue/Extraction.psm1
@@ -75,6 +75,7 @@ function Show-ExtractionHelpDoc {
         [Parameter(Mandatory = $true)]
         [Int] $IssueID,
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [string] $IssueBody
     )
 


### PR DESCRIPTION
### Motivation
https://github.com/ScoopInstaller/GithubActions/blob/63f20efd5d6f876b16fbe2bc95428821b6051c0e/src/Action/Issue/Extraction.psm1#L77-L78
The mandatory parameter validation was failing because the issue body could be empty.
```
INFO: Issue initialized
Detected issue type: Decompression/Extraction error.
Show-ExtractionHelpDoc: Cannot bind argument to parameter 'IssueBody' because it is an empty string.
INFO: Issue finished
```
### Related Issues/PRs
- #78
- https://github.com/ScoopInstaller/Main/issues/8014
  - https://github.com/ScoopInstaller/Main/actions/runs/25908638224/job/76147869244
- https://github.com/ScoopInstaller/Extras/issues/17821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Improved parameter handling to accept empty string values in issue body field processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/GithubActions/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->