### PR TITLE
fix: restore global ErrorActionPreference override

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -1,3 +1,7 @@
+# Set Global Preference
+# FIXME(chawyehsu): see https://github.com/ScoopInstaller/GithubActions/pull/86#discussion_r3795404713
+$Global:ErrorActionPreference = 'Continue'
+
 # Import all modules
 Join-Path $PSScriptRoot 'src' | Get-ChildItem -File | Select-Object -ExpandProperty Fullname | Import-Module
 


### PR DESCRIPTION
Relates to #86 and #32

Also relates to https://github.com/ScoopInstaller/Scoop/pull/6652 (https://github.com/ScoopInstaller/Scoop/pull/5407).