### PR TITLE
refactor: use irm for scoop install

### DIFF
--- a/.pslintrules.psd1
+++ b/.pslintrules.psd1
@@ -26,6 +26,8 @@
         # https://github.com/PowerShell/PSScriptAnalyzer/issues/636
         'PSUseDeclaredVarsMoreThanAssignments',
         # `Write-LogInfo` uses `Write-Host` currently.
-        'PSAvoidUsingWriteHost'
+        'PSAvoidUsingWriteHost',
+        # Invoke-Expression is used to run the scoop installer script.
+        'PSAvoidUsingInvokeExpression'
     )
 }

--- a/action.ps1
+++ b/action.ps1
@@ -10,7 +10,6 @@ Install-Scoop
 Test-NestedBucket
 Initialize-NeededConfiguration
 
-git config --get user.email
 Write-LogInfo 'Importing all modules'
 # Load all scoop's modules.
 # Dot sourcing needs to be done on highest scope possible to propagate into lower scopes

--- a/src/Scoop.psm1
+++ b/src/Scoop.psm1
@@ -6,9 +6,7 @@ function Install-Scoop {
         Install scoop using new installer.
     #>
     Write-LogInfo 'Installing scoop'
-    $f = Join-Path $env:USERPROFILE 'install.ps1'
-    Invoke-WebRequest 'https://raw.githubusercontent.com/ScoopInstaller/Install/master/install.ps1' -UseBasicParsing -OutFile $f
-    & $f -RunAsAdmin
+    Invoke-RestMethod 'https://raw.githubusercontent.com/ScoopInstaller/Install/master/install.ps1' | Invoke-Expression
     if ($env:SCOOP_REPO) {
         Write-LogInfo "Switching to repository: ${env:SCOOP_REPO}"
         scoop config scoop_repo $env:SCOOP_REPO


### PR DESCRIPTION
The installer can run on GitHub CI without `RunAsAdmin` flag, https://github.com/ScoopInstaller/Install/pull/77